### PR TITLE
改善ModLoader加载过程中的内存占用问题

### DIFF
--- a/boot.json
+++ b/boot.json
@@ -4,15 +4,13 @@
   "styleFileList": [
   ],
   "scriptFileList_earlyload": [
+    "dist/i18nLoad.js",
     "dist/earlyload/earlyload.js"
   ],
   "scriptFileList_inject_early": [
-    "node_modules/jszip/dist/jszip.js",
-    "dist/TypeB.js",
-    "dist/I18N.js"
+    "node_modules/jszip/dist/jszip.js"
   ],
   "scriptFileList_preload": [
-    "dist/preload/preload.js"
   ],
   "scriptFileList": [
   ],

--- a/package.json
+++ b/package.json
@@ -6,14 +6,18 @@
   "scripts": {
     "ts:build": "tsc -p ./src/tsconfig.json",
     "ts:w": "tsc -w -p ./src/tsconfig.json",
-    "ts:tool:w": "tsc -w -p ./tool/tsconfig.json"
+    "ts:tool:w": "tsc -w -p ./tool/tsconfig.json",
+    "ts:test": "tsc -p ./test/tsconfig.json",
+    "build:webpack": "webpack -c ./webpack.config.js",
+    "test": "node ./dist-tool/jsonTest.js i18n.json"
   },
   "packageManager": "yarn@3.4.1",
   "dependencies": {
     "@types/jquery": "^3.5.19",
     "json5": "^2.2.3",
     "jszip": "^3.10.1",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "@streamparser/json": "^0.0.17"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.198",

--- a/src/I18N.ts
+++ b/src/I18N.ts
@@ -3,7 +3,11 @@
 /// <reference path="../../../dist-BeforeSC2/ModLoader.d.ts" />
 /// <reference path="./winDef.d.ts" />
 
-class ModI18N {
+// 因为 @streamparser/json 无法正常工作，所以我这里改成了这样
+import {JSONParser} from "../node_modules/@streamparser/json/dist/mjs/index.js";//@streamparser/json
+import {TypeBOutputText, TypeBInputStoryScript, ModI18NTypeB} from "./TypeB";
+
+export class ModI18N {
     modUtils = window.modUtils;
     modSC2DataManager = window.modSC2DataManager;
 
@@ -15,7 +19,7 @@ class ModI18N {
     }
 
 
-    checkItem(t: TypeBInputStoryScript) {
+    checkItem(t: any): t is TypeBInputStoryScript{
         let c = t
             && this._.isString(this._.get(t, 'f'))
             && this._.isString(this._.get(t, 't'))
@@ -77,6 +81,99 @@ class ModI18N {
         }
     }
 
+
+    async readZipStream() {
+        this.logger.log('patching i18n mod ........');
+        const selfZip = this.modSC2DataManager.getModLoader().getModZip('ModI18N');
+
+        if (selfZip) {
+
+            const parser = new JSONParser({
+                stringBufferSize: 1024,
+                keepStack: false,
+                paths: ['$.typeB.TypeBOutputText.*', '$.typeB.TypeBInputStoryScript.*']
+            });
+            let resultB : TypeBOutputText[]= [];
+            let resultBInput : TypeBInputStoryScript[] = [];
+
+            var maxusage = 0;
+            parser.onValue = ({value, key, parent, stack}) => {
+                if(stack.length < 2) return;
+                if (stack[2].key === 'TypeBOutputText'){
+                    if (this.checkItem(value)) {
+                        resultB.push({
+                            // @ts-ignore
+                            from: value.f,
+                            // @ts-ignore
+                            to: value.t,
+                            // @ts-ignore
+                            pos: value.pos,
+                            fileName: value.fileName,
+                            js: value.js
+                        });
+                    }
+                }
+                else if(stack[2].key === 'TypeBInputStoryScript')
+                {
+                    if (this.checkItem(value)) {
+                        resultBInput.push({
+                            // @ts-ignore
+                            from: value.f,
+                            // @ts-ignore
+                            to: value.t,
+                            // @ts-ignore
+                            pos: value.pos,
+                            fileName: value.fileName,
+                            // @ts-ignore
+                            passageName: value.pN
+                        });
+                    }
+                }
+                if (parent !== undefined) {
+                    //console.log(parent.length);
+                    //const used = process.memoryUsage().heapUsed / 1024 / 1024;
+                    //if (used > maxusage)
+                    //    maxusage = used;
+                    parent.length = 0;
+                }
+            };
+            const zipStream = selfZip.zip.file('i18n.json')?.async("string").then((content : string) => {
+                parser.write(content);
+            });
+            await zipStream;
+            //.pipe(JSONStream.parse(['typeB', '']))
+
+            this.typeB = new ModI18NTypeB(resultB, resultBInput);
+
+            this.startReplace();
+        }
+    }
+
+    private startReplace()
+    {
+        if (this.typeB === undefined) return;
+        // start replace
+        const sc2DataCache = this.modSC2DataManager.getSC2DataInfoAfterPatch();
+        // console.log('i18nJson sc2DataCache', sc2DataCache);
+        const sc2Data = sc2DataCache.cloneSC2DataInfo();
+        // console.log('i18nJson sc2Data', sc2Data);
+
+        for (const T of sc2Data.styleFileItems.items) {
+            T.content = this.typeB.replaceCss(T.content, T.name);
+        }
+        for (const T of sc2Data.scriptFileItems.items) {
+            T.content = this.typeB.replaceJs(T.content, T.name);
+        }
+
+        for (const pd of sc2Data.passageDataItems.items) {
+            pd.content = this.typeB.replaceInputStoryScript(pd.content, pd.name);
+        }
+
+        console.log('sc2DataCache', sc2DataCache);
+        console.log('sc2Data', sc2Data);
+        this.modUtils.replaceFollowSC2DataInfo(sc2Data, sc2DataCache);
+    }
+
     async readZipSelf() {
 
         this.logger.log('patching i18n mod ........');
@@ -103,27 +200,7 @@ class ModI18N {
                 }
                 this.typeB = new ModI18NTypeB(cc[0], cc[1]);
 
-                // start replace
-                const sc2DataCache = this.modSC2DataManager.getSC2DataInfoAfterPatch();
-                // console.log('i18nJson sc2DataCache', sc2DataCache);
-                const sc2Data = sc2DataCache.cloneSC2DataInfo();
-                // console.log('i18nJson sc2Data', sc2Data);
-
-                for (const T of sc2Data.styleFileItems.items) {
-                    T.content = this.typeB.replaceCss(T.content, T.name);
-                }
-                for (const T of sc2Data.scriptFileItems.items) {
-                    T.content = this.typeB.replaceJs(T.content, T.name);
-                }
-
-                for (const pd of sc2Data.passageDataItems.items) {
-                    pd.content = this.typeB.replaceInputStoryScript(pd.content, pd.name);
-                }
-
-                console.log('sc2DataCache', sc2DataCache);
-                console.log('sc2Data', sc2Data);
-                this.modUtils.replaceFollowSC2DataInfo(sc2Data, sc2DataCache);
-
+                this.startReplace();
             }
 
         } else {

--- a/src/TypeB.ts
+++ b/src/TypeB.ts
@@ -1,5 +1,5 @@
 // original OutputText -> (dontTrim/Trim) -> match `from:string` -> replace use to string
-interface TypeBOutputText {
+export interface TypeBOutputText {
     from: string;
     to: string;
 
@@ -80,7 +80,7 @@ function fuzzyMatchManual(strA: string, strB: string, startIndex = 0) {
 }
 
 // original StoryScript -> (dontTrim/Trim) -> (dontTrimTag/TrimTag) Trim or not in original string -> match `from:string` -> notMatchRegex filer -> replace use to string
-interface TypeBInputStoryScript {
+export interface TypeBInputStoryScript {
     from: string;
     to: string;
 
@@ -376,7 +376,7 @@ class ModI18NTypeB_JsCssMatcher {
 
 }
 
-class ModI18NTypeB {
+export class ModI18NTypeB {
 
     constructor(
         public OutputText: TypeBOutputText[],

--- a/src/earlyload/earlyload.ts
+++ b/src/earlyload/earlyload.ts
@@ -1,8 +1,9 @@
+
+
 (async () => {
+
     console.log('ModI18N earlyload start');
 
-    window.modI18N = new ModI18N();
-
-    await window.modI18N.readZipSelf();
+    await window.modI18N.readZipStream();
 
 })();

--- a/src/earlyload/initModule.ts
+++ b/src/earlyload/initModule.ts
@@ -1,0 +1,4 @@
+import {ModI18N} from "../I18N";
+console.log('ModI18N earlyload init module');
+
+window.modI18N = new ModI18N();

--- a/test/jsonTest.ts
+++ b/test/jsonTest.ts
@@ -1,0 +1,238 @@
+/// <reference path="../../../dist-BeforeSC2/SC2DataManager.d.ts" />
+/// <reference path="../../../dist-BeforeSC2/Utils.d.ts" />
+/// <reference path="../../../dist-BeforeSC2/ModLoader.d.ts" />
+/// <reference path="../src/winDef.d.ts" />
+/// <reference path="../dist/typeB.d.ts" />
+
+import JSZip from 'jszip';
+import fs from 'fs';
+import path from 'path';
+import {promisify} from 'util';
+import _ from "lodash";
+const { Writable } = require('stream');
+const { pipeline } = require('stream');
+
+
+
+import {JSONParser} from "@streamparser/json";
+
+const lodash = _;
+function checkItem(t: any): t is TypeBInputStoryScript {
+    let c = t
+        && lodash.isString(lodash.get(t, 'f'))
+        && lodash.isString(lodash.get(t, 't'))
+        && lodash.isNumber(lodash.get(t, 'pos'));
+    if (t.passageName) {
+        c = c && lodash.isString(t.passageName);
+    }
+    if (lodash.has(t, 'pN')) {
+        c = c && lodash.isString(lodash.get(t, 'pN'));
+    }
+    if (t.css || t.js) {
+        c = c && lodash.isString(t.fileName);
+    }
+    // console.log('checkItem', [c, [
+    //     lodash.isString(lodash.get(t, 'f')),
+    //     lodash.isString(lodash.get(t, 't')),
+    //     lodash.isNumber(lodash.get(t, 'pos')),
+    //     t.passageName ? lodash.isString(t.passageName) : true,
+    //     lodash.has(t, 'pN') ? lodash.isString(lodash.get(t, 'pN')) : true,
+    //     t.css || t.js ? lodash.isString(t.fileName) : true,
+    // ]]);
+    return c;
+}
+
+function checkAndProcessData(T: any): [TypeBOutputText[], TypeBInputStoryScript[]] | undefined {
+    if (T && T.typeB && T.typeB.TypeBOutputText && T.typeB.TypeBInputStoryScript) {
+        const cacheTypeBOutputText = T.typeB.TypeBOutputText.map((T: any) => {
+            if (!checkItem(T)) {
+                console.error('I18NMod checkAndProcessData TypeBOutputText (!this.checkItem(T))', T);
+            }
+            //下面的写法最终占用 134 MB
+            return {
+                from: T.f,
+                to: T.t,
+                pos: T.pos,
+                fileName: T.fileName,
+                js: T.js
+            };
+            //下面的写法最终占用 142 MB
+            return Object.assign(T, {
+                from: T.f,
+                to: T.t,
+            });
+        });
+        const cacheTypeBInputStoryScript = T.typeB.TypeBInputStoryScript.map((T: any): TypeBInputStoryScript => {
+            if (!checkItem(T)) {
+                console.error('I18NMod checkAndProcessData TypeBInputStoryScript (!this.checkItem(T))', T);
+            }
+            //下面的写法最终占用 134 MB
+            return {
+                from: T.f,
+                to: T.t,
+                pos: T.pos,
+                fileName: T.fileName,
+                passageName: T.pN
+            };
+            //下面的写法最终占用 142 MB
+            return Object.assign(T, {
+                from: T.f,
+                to: T.t,
+                passageName: T.pN,
+            } as TypeBInputStoryScript);
+        });
+
+        return [cacheTypeBOutputText, cacheTypeBInputStoryScript];
+    }
+    return undefined;
+}
+
+;(async () => {
+    const parser = new JSONParser({
+        stringBufferSize: 1024,
+        keepStack: false,
+        paths: ['$.typeB.TypeBOutputText.*', '$.typeB.TypeBInputStoryScript.*']
+    });
+    let resultB : TypeBOutputText[]= [];
+    let resultBInput : TypeBInputStoryScript[] = [];
+
+    var maxusage = 0;
+    parser.onValue = ({value, key, parent, stack}) => {
+        if(stack.length < 2) return;
+        if (stack[2].key === 'TypeBOutputText'){
+            if (checkItem(value)) {
+
+                //上面的写法会占用 150。3 MB的内存
+                /*
+                resultB.push(Object.assign(value, {
+                    // @ts-ignore
+                    from: value.f,
+                    // @ts-ignore
+                    to: value.t,
+                }));*/
+                //下面的写法会占用 144.07MB的内存
+
+                resultB.push({
+                    // @ts-ignore
+                    from: value.f,
+                    // @ts-ignore
+                    to: value.t,
+                    // @ts-ignore
+                    pos: value.pos,
+                    fileName: value.fileName,
+                    js: value.js
+                });
+            }
+        }
+        else if(stack[2].key === 'TypeBInputStoryScript')
+        {
+            if (checkItem(value)) {/*
+                resultB.push(Object.assign(value, {
+                    // @ts-ignore
+                    from: value.f,
+                    // @ts-ignore
+                    to: value.t,
+                    // @ts-ignore
+                    passageName: value.pN,
+                }));*/
+
+
+                resultBInput.push({
+                    // @ts-ignore
+                    from: value.f,
+                    // @ts-ignore
+                    to: value.t,
+                    // @ts-ignore
+                    pos: value.pos,
+                    fileName: value.fileName,
+                    // @ts-ignore
+                    passageName: value.pN
+                });
+            }
+        }
+        if (parent !== undefined) {
+            //console.log(parent.length);
+            //const used = process.memoryUsage().heapUsed / 1024 / 1024;
+            //if (used > maxusage)
+            //    maxusage = used;
+            parent.length = 0;
+        }
+    };
+
+// Or passing the stream in several chunks
+    try {
+
+        const jsonPath = process.argv[2];
+        console.log('jsonPath', jsonPath);
+        if (!jsonPath) {
+            console.error('no jsonPath');
+        }
+        {
+
+            const used = process.memoryUsage().heapUsed / 1024 / 1024;
+            console.log(`The script uses before read  ${Math.round(maxusage * 100) / 100} MB`);
+        }
+
+        if (false)
+        {
+            //这个代码段测试流式情况下的峰值内存占用
+            //流式的情况下，内存占用为 53.31MB，远小于原本的大小
+            const readStream = fs.createReadStream(jsonPath, {encoding: 'utf-8'});
+
+            readStream.on('data', (chunk) => {
+                // 处理每一个数据块
+                parser.write(chunk);
+            });
+            // 创建一个“空操作”的可写流
+            const noopWritable = new Writable({
+                write(chunk: any, encoding: any, callback: () => void) {
+                    // 这里不做任何操作，只是调用回调函数
+                    callback();
+                }
+            });
+            const pipelineAsync = promisify(pipeline);
+            await pipelineAsync(readStream, noopWritable);
+            {
+                const used = process.memoryUsage().heapUsed / 1024 / 1024;
+                if (used > maxusage)
+                    maxusage = used;
+            }
+            console.info('Size:' + resultB.length + ' ' + resultBInput.length);
+        }
+        else {
+            const jsonF = await promisify(fs.readFile)(jsonPath, {encoding: 'utf-8'});
+            //通过上面的parser解码完后是 135.31 MB
+            parser.write(jsonF);
+            console.info('Size:' + resultB.length + ' ' + resultBInput.length);
+
+            //如果直接通过下面的代码进行parse，会直接占用约 40MiB(124.46MB) 的内存，在不进行任何解码操作的前提下
+            //解码完成后则是占用 142.87MB
+            //优化后占用可以降低到 134 MB
+            /*
+            let i18nJson;
+            try {
+                i18nJson = JSON.parse(jsonF);
+            } catch (e) {
+                console.error(e);
+            }
+            const cc = checkAndProcessData(i18nJson);*/
+            {
+                const used = process.memoryUsage().heapUsed / 1024 / 1024;
+                if (used > maxusage)
+                    maxusage = used;
+            }
+        }
+
+        // onValue will be called 3 times:
+        // "a"
+        // ["a"]
+        // { test: ["a"] }
+    } catch (err) {
+        console.log(err); // handler errors
+    }
+
+
+    console.log(`The script uses max  ${Math.round(maxusage * 100) / 100} MB`);
+})().catch((e) => {
+    console.error(e);
+});

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,115 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "ES2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": ["DOM", "ES2022"],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "Node16",                                /* Specify what module code is generated. */
+    "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "moduleResolution": "node16",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    "types": [
+    ],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "outFile": "../dist-tool/out.js",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    "outDir": "../dist-tool",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "webpack.config.js"
+  ]
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,108 @@
+// Generated using webpack-cli https://github.com/webpack/webpack-cli
+
+const path = require('path');
+const fs = require('fs');
+// const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+const isProduction = process.env.NODE_ENV == 'production';
+
+
+const stylesHandler = 'style-loader';
+
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+
+// const ZipPlugin = require('zip-webpack-plugin');
+
+const webpack = require('webpack');
+
+const config = {
+  entry: './src/earlyload/initModule.ts',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'i18nLoad.js',
+  },
+  devtool: 'inline-source-map',
+  target: 'web',
+  // devServer: {
+  //   open: true,
+  //   host: '0.0.0.0',
+  //   port: 3000,
+  // },
+  plugins: [
+    // new HtmlWebpackPlugin({
+    //   template: 'src/web/1.html',
+    // }),
+    new ForkTsCheckerWebpackPlugin({
+      typescript: {
+        configFile: 'src/tsconfig.json',
+        memoryLimit: 4096,
+      },
+    }),
+
+    // new webpack.BannerPlugin({
+    //   banner: fs.readFileSync('./src/GreasemonkeyScript/gm_front.txt', {encoding: 'utf-8'}),
+    //   raw: true,
+    // }),
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.(ts|tsx)$/i,
+        loader: 'ts-loader',
+        exclude: ['/node_modules/'],
+      },
+      // {
+      //   test: /\.css$/i,
+      //   use: [stylesHandler, 'css-loader'],
+      // },
+      // {
+      //   test: /\.s[ac]ss$/i,
+      //   use: [stylesHandler, 'css-loader', 'sass-loader'],
+      // },
+      {
+        test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
+        type: 'asset',
+      },
+
+      // https://stackoverflow.com/questions/42631645/webpack-import-typescript-module-both-normally-and-as-raw-string
+      {
+        // test: /.*\/inlineText\/.*/,
+        resourceQuery: /inlineText/,
+        type: 'asset/source',
+      },
+      // {
+      //   test: /src\/inlineText\/GM\.css/,
+      //   use: 'raw-loader',
+      // },
+
+      // Add your rules for custom modules here
+      // Learn more about loaders from https://webpack.js.org/loaders/
+    ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.jsx', '.js', '...'],
+    plugins: [new TsconfigPathsPlugin({
+      configFile: 'src/tsconfig.json',
+    })],
+    alias: {
+      // GM_config: './src/libs/GM_config/gm_config.js',
+    },
+    fallback: {
+      // for libsodium
+      // only in browser
+      crypto: false,
+    },
+  },
+};
+
+module.exports = () => {
+  if (isProduction) {
+    config.mode = 'production';
+
+
+  } else {
+    config.mode = 'development';
+  }
+  return config;
+};


### PR DESCRIPTION
主要的修改思路是：
1. 减小了  TypeBInputStoryScript 结构的大小，在加载后将 `f` `t` 字段剔除。
2. 将 Zip 加载部分的逻辑变为流式的加载（因此引入了@streamparser/json 依赖），避免完整字符串的加载对内存的开销。

总体而言速度相对之前变慢了一些，但是峰值内存占用，从原本的 142.87 MB，变为了 53.31 MB（用 i18n.json ，在 node 14.20.1 环境进行测试），具体测试代码在 `jsonTest.ts` 中。

在处理 mod 加载的问题期间，对 earlyload.ts 部分进行了一部分变更，我感觉这部分修改肯定不是推荐的做法，希望能给出一些建议。


看起来，要让 earlyload 的异步逻辑正常，指定的js里面不能加 import ，module 不能是 `NodeNext`？